### PR TITLE
cleans up duplicate event_ids from heap

### DIFF
--- a/macros/base/heap_events.sql
+++ b/macros/base/heap_events.sql
@@ -7,12 +7,26 @@
 
 {% macro default__heap_events() %}
 
-select 
-    
-    *,
-    {{heap.time_field('event_time')}}
-    
-from {{ source('heap', 'all_events') }}
-qualify ROW_NUMBER() over (partition by event_id order by time) = 1
+with events as
+(
+    select 
+        
+        *,
+        {{heap.time_field('event_time')}},
+        row_number() over (partition by event_id order by time) as row_number
+        
+    from {{ source('heap', 'all_events') }}
+)
+
+select
+    event_id,
+    time,
+    user_id,
+    session_id,
+    event_table_name,
+    event_time
+from events
+-- add row number filter to remove duplicate rows
+where row_number = 1
 
 {% endmacro %}

--- a/macros/base/heap_events.sql
+++ b/macros/base/heap_events.sql
@@ -13,5 +13,6 @@ select
     {{heap.time_field('event_time')}}
     
 from {{ source('heap', 'all_events') }}
+qualify ROW_NUMBER() over (partition by event_id order by time) = 1
 
 {% endmacro %}


### PR DESCRIPTION
# New Pull Request

Check off the things that are applicable.  Some sections are mandetory for a review to continue.

Note: for the checkbox to format correctly, make sure there aren't any spaces between [ ]
- [x] completed task
- [ ] incomplete task

## What has changed?
- [ ] New Models
- [x] Updated Models
- [ ] Config Change

### What issue is this PR meant to fix?
I had an instance of two duplicate rows (same event_id) in the raw data from the heap events table

### Provide any context to assist the reviewer and a speedy PR turnaround:
This cleans that up so the heap_events model can pass its schema tests. Tested locally for gooten and it fixed the schema test failure.  

### Complexity
- [ ] Simple 1-liner, please rubber stamp
- [x] Simple model update.  I don't expect any issues
- [ ] Business rules.  Need another set of eyes.  I have provided detailed context and documentations on how rules are meant to function
- [ ] Massive re-write.  What have I done?

## Model Changes
All of the following exist:
- [x] Schema exist for the new/updated model
- [x] An appropriate unique test exists in schema

If the above is not applicable specify why:
- [ ] No model changes
- [ ] other:

## Development Process
I have done all:
- [x] `dbt run` locally
- [x] `dbt test` locally

or:
- [ ] It wasn't necessary because: 

*Note:  Pull Requests will not be reviewed otherwise*
